### PR TITLE
Bugfix/sveltkit slug issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikigen",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5335,7 +5335,7 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wiki_gen"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "image 0.25.1",
  "indexmap 2.2.6",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiki_gen"
-version = "0.5.1"
+version = "0.5.2"
 description = "A Desktop Application to generate wikis for Pokemon Rom Hacks"
 authors = ["Akeem Allen"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "WikiGen",
-    "version": "0.5.1"
+    "version": "0.5.2"
   },
   "tauri": {
     "allowlist": {

--- a/src/routes/game-routes/[slug]/+page.js
+++ b/src/routes/game-routes/[slug]/+page.js
@@ -3,3 +3,9 @@ export function load({ params }) {
     title: params.slug,
   };
 }
+
+export function entries() {
+  return [{ slug: "hello-world" }];
+}
+
+export const prerender = true;


### PR DESCRIPTION
Was getting the below error when trying to build app. Just following instruction on sveltekit page to solve.

"""
Error: The following routes were marked as prerenderable, but were not prerendered because they were not found while crawling your app:
  - /game-routes/[slug]

"""