### PR TITLE
Feature/46 create new pokemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikigen",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "wiki_gen"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wiki_gen"
-version = "0.12.1"
+version = "0.13.0"
 description = "A Desktop Application to generate wikis for Pokemon Rom Hacks"
 authors = ["Akeem Allen"]
 license = ""
 repository = ""
 default-run = "wiki_gen"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.76"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/page_generators/pokemon_page_generator_functions.rs
+++ b/src-tauri/src/page_generators/pokemon_page_generator_functions.rs
@@ -29,7 +29,10 @@ pub fn create_defenses_table(
     types: String,
     calculated_defenses: &HashMap<String, TypeEffectiveness>,
 ) -> String {
-    let types = types.split(",").collect::<Vec<&str>>();
+    let mut types = types.split(",").collect::<Vec<&str>>();
+    if types.len() == 1 {
+        types.push("none")
+    }
     // Get Defensive Matchups from file before calculating them
     let defensive_matchups = match calculated_defenses.get(&types.join("-").to_string()) {
         Some(matchup) => matchup.0.clone(),

--- a/src-tauri/src/page_generators/pokemon_pages.rs
+++ b/src-tauri/src/page_generators/pokemon_pages.rs
@@ -257,7 +257,7 @@ fn extract_pokemon_id(key: Option<&str>) -> i32 {
         .unwrap();
 }
 
-fn generate_pokemon_page(
+pub fn generate_pokemon_page(
     calculated_defenses: &HashMap<String, TypeEffectiveness>,
     pokemon: &DBPokemon,
     movesets: Vec<PokemonMove>,

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2,34 +2,44 @@
 pub mod tests {
     use std::path::PathBuf;
 
-    #[test]
-    fn test_create_dir_all() {
-        let base_path =
-            PathBuf::from("/Users/akeemallen/Library/Application Support/com.wikigen.dev/test");
-        let base_path_2 =
-            PathBuf::from("/Users/akeemallen/Library/Application Support/com.wikigen.dev/Test");
+    use crate::page_generators::pokemon_pages::generate_pokemon_page;
 
-        match std::fs::create_dir_all(&base_path) {
-            Ok(_) => {
-                println!("Lower case Directory created");
-            }
-            Err(err) => {
-                println!("Error creating lower case directory: {}", err);
-            }
-        };
-        let path_1_exists = base_path.try_exists().unwrap();
-        println!("{:?}", path_1_exists);
+    // #[test]
+    // fn test_create_dir_all() {
+    //     let base_path =
+    //         PathBuf::from("/Users/akeemallen/Library/Application Support/com.wikigen.dev/test");
+    //     let base_path_2 =
+    //         PathBuf::from("/Users/akeemallen/Library/Application Support/com.wikigen.dev/Test");
 
-        match std::fs::create_dir_all(&base_path_2) {
-            Ok(_) => {
-                println!("Higher case Directory created");
-            }
-            Err(err) => {
-                println!("Error creating higher case directory: {}", err);
-            }
-        };
+    //     match std::fs::create_dir_all(&base_path) {
+    //         Ok(_) => {
+    //             println!("Lower case Directory created");
+    //         }
+    //         Err(err) => {
+    //             println!("Error creating lower case directory: {}", err);
+    //         }
+    //     };
+    //     let path_1_exists = base_path.try_exists().unwrap();
+    //     println!("{:?}", path_1_exists);
 
-        let path_2_exists = base_path_2.try_exists().unwrap();
-        println!("{:?}", path_2_exists);
-    }
+    //     match std::fs::create_dir_all(&base_path_2) {
+    //         Ok(_) => {
+    //             println!("Higher case Directory created");
+    //         }
+    //         Err(err) => {
+    //             println!("Error creating higher case directory: {}", err);
+    //         }
+    //     };
+
+    //     let path_2_exists = base_path_2.try_exists().unwrap();
+    //     println!("{:?}", path_2_exists);
+    // }
+
+    // #[test]
+    // fn test_generate_pokemon_page(){
+    //     let base_path =
+    //                 PathBuf::from("/Users/akeemallen/Library/Application Support/com.wikigen.dev/test-wiki");
+
+    //     let result = generate_pokemon_page(&base_path, &pokemon);
+    // }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "WikiGen",
-    "version": "0.12.1"
+    "version": "0.13.0"
   },
   "tauri": {
     "allowlist": {

--- a/src/lib/components/NewPokemonPanel.svelte
+++ b/src/lib/components/NewPokemonPanel.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+import Button from "$lib/components/Button.svelte";
+import PokemonDetailsTab from "./PokemonDetailsTab.svelte";
+import { getToastStore, Tab, TabGroup } from "@skeletonlabs/skeleton";
+import { type Pokemon } from "../../store/pokemon";
+import { db } from "../../store/db";
+import NumberInput from "./NumberInput.svelte";
+import TextInput from "./TextInput.svelte";
+import { BaseDirectory, writeBinaryFile } from "@tauri-apps/api/fs";
+import { selectedWiki } from "../../store";
+import { base64ToArray } from "$lib/utils";
+
+const toastStore = getToastStore();
+
+let tabSet: number = 0;
+let newSpriteImage: string = "";
+let newPokemon: Pokemon = {
+  dex_number: 0,
+  name: "",
+  types: "normal",
+  ability_1: null,
+  ability_2: null,
+  hp: 0,
+  attack: 0,
+  defense: 0,
+  sp_attack: 0,
+  sp_defense: 0,
+  speed: 0,
+} as Pokemon;
+
+function onImageUpload(e: any) {
+  let file = e.target.files[0];
+  let reader = new FileReader();
+  reader.onloadend = (e) => {
+    let base64 = e.target?.result as string;
+    if (!base64.includes("data:image/png;base64,")) {
+      toastStore.trigger({
+        message: "Invalid image format!",
+        background: "variant-filled-error",
+      });
+      return;
+    }
+    newSpriteImage = e.target?.result as string;
+  };
+  reader.readAsDataURL(file);
+}
+
+async function createNewPokemon() {
+  await $db
+    .execute(
+      `INSERT INTO pokemon (
+          dex_number,
+          name,
+          types,
+          ability_1,
+          ability_2,
+          hp, attack, defense, sp_attack, sp_defense, speed, evolution_method
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);`,
+      [
+        newPokemon.dex_number,
+        newPokemon.name,
+        newPokemon.types,
+        newPokemon.ability_1,
+        newPokemon.ability_2,
+        newPokemon.hp,
+        newPokemon.attack,
+        newPokemon.defense,
+        newPokemon.sp_attack,
+        newPokemon.sp_defense,
+        newPokemon.speed,
+        "no_change",
+      ],
+    )
+    .then(() => {
+      // Write image to file
+      const imageBytes = base64ToArray(
+        newSpriteImage.replace("data:image/png;base64,", ""),
+        "image/png",
+      );
+      writeBinaryFile(
+        `${$selectedWiki.name}/dist/docs/img/pokemon/${newPokemon.name}.png`,
+        imageBytes,
+        { dir: BaseDirectory.AppData },
+      ).catch((err) => {
+        toastStore.trigger({
+          message: "Error writing image to file!",
+          background: "variant-filled-error",
+        });
+      });
+
+      toastStore.trigger({
+        message: "New Pokemon created!",
+        background: "variant-filled-success",
+      });
+    })
+    .catch((err) => {
+      toastStore.trigger({
+        message: "Error creating new Pokemon!",
+        background: "variant-filled-error",
+      });
+    });
+}
+</script>
+
+<Button title="Save New Pokemon" class="mt-2 w-40" onClick={createNewPokemon} />
+<div class="mb-4 mt-4">
+  <label
+    for="sprite-image"
+    class="block text-sm font-medium leading-6 text-gray-900"
+    >Pokemon Sprite</label
+  >
+  {#if newSpriteImage !== ""}
+    <img src={newSpriteImage} alt="Sprite" />
+  {/if}
+  <input
+    id="sprite-image"
+    type="file"
+    accept="image/png"
+    class="mt-2"
+    on:change={onImageUpload}
+  />
+</div>
+
+<div class="mb-5 mt-5 flex flex-row gap-5">
+  <TextInput label="Pokemon Name" bind:value={newPokemon.name} class="w-40" />
+  <NumberInput
+    label="Dex Number"
+    bind:value={newPokemon.dex_number}
+    class="w-40"
+  />
+</div>
+
+<TabGroup>
+  <Tab bind:group={tabSet} name="pokemon-details" value={0} class="text-sm"
+    >Details</Tab
+  >
+  <Tab bind:group={tabSet} name="pokemon-moves" value={1} class="text-sm"
+    >Moves</Tab
+  >
+  <svelte:fragment slot="panel">
+    {#if tabSet === 0}
+      <PokemonDetailsTab bind:pokemon={newPokemon} isNewPokemon={true} />
+    {/if}
+    <!-- {#if tabSet === 1}
+      <PokemonMovesTab
+        bind:moveset={pokemonMoveset}
+        bind:pokemonId={pokemon.id}
+        generatePokemonPage={generatePokemonPage}
+      />
+    {/if} -->
+  </svelte:fragment>
+</TabGroup>

--- a/src/lib/components/NewPokemonPanel.svelte
+++ b/src/lib/components/NewPokemonPanel.svelte
@@ -141,6 +141,9 @@ async function createNewPokemon() {
         });
       });
 
+      // Add new pokemon to pokemonList
+      $pokemonList.push([res.lastInsertId, newPokemon.name]);
+
       toastStore.trigger({
         message: "New Pokemon created!",
         background: "variant-filled-success",

--- a/src/lib/components/NewPokemonPanel.svelte
+++ b/src/lib/components/NewPokemonPanel.svelte
@@ -155,12 +155,17 @@ async function createNewPokemon() {
 }
 </script>
 
-<Button title="Save New Pokemon" class="mt-2 w-40" onClick={createNewPokemon} />
+<Button
+  title="Save New Pokemon"
+  class="mt-2 w-40"
+  onClick={createNewPokemon}
+  disabled={newPokemon.dex_number === 0 || newPokemon.name === "" || newSpriteImage === ""}
+/>
 <div class="mb-4 mt-4">
   <label
     for="sprite-image"
     class="block text-sm font-medium leading-6 text-gray-900"
-    >Pokemon Sprite</label
+    >Pokemon Sprite*</label
   >
   {#if newSpriteImage !== ""}
     <img src={newSpriteImage} alt="Sprite" />
@@ -176,7 +181,7 @@ async function createNewPokemon() {
 
 <div class="mb-5 mt-5 flex flex-row gap-5">
   <TextInput
-    label="Pokemon Name"
+    label="Pokemon Name*"
     bind:value={newPokemon.name}
     class="w-40"
     inputHandler={(e) => {
@@ -184,7 +189,7 @@ async function createNewPokemon() {
       }}
   />
   <NumberInput
-    label="Dex Number"
+    label="Dex Number*"
     bind:value={newPokemon.dex_number}
     class="w-40"
   />

--- a/src/lib/components/NewPokemonPanel.svelte
+++ b/src/lib/components/NewPokemonPanel.svelte
@@ -94,7 +94,7 @@ async function createNewPokemon() {
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);`,
       [
         newPokemon.dex_number,
-        newPokemon.name,
+        newPokemon.name.toLowerCase(),
         newPokemon.types,
         newPokemon.ability_1,
         newPokemon.ability_2,
@@ -175,7 +175,14 @@ async function createNewPokemon() {
 </div>
 
 <div class="mb-5 mt-5 flex flex-row gap-5">
-  <TextInput label="Pokemon Name" bind:value={newPokemon.name} class="w-40" />
+  <TextInput
+    label="Pokemon Name"
+    bind:value={newPokemon.name}
+    class="w-40"
+    inputHandler={(e) => {
+        newPokemon.name = e.target.value.toLowerCase().replaceAll(" ", "-");
+      }}
+  />
   <NumberInput
     label="Dex Number"
     bind:value={newPokemon.dex_number}

--- a/src/lib/components/PokemonDetailsTab.svelte
+++ b/src/lib/components/PokemonDetailsTab.svelte
@@ -9,6 +9,7 @@ import { abilitiesList } from "../../store/abilities";
 import { itemsList } from "../../store/items";
 
 export let pokemon: Pokemon = {} as Pokemon;
+export let isNewPokemon: boolean = false;
 
 let pokemonListOptions = $pokemonList.map(([id, name]) => ({
   label: _.capitalize(name),
@@ -118,61 +119,63 @@ function onTypeChange(e: any, type_number: string) {
       class="w-full"
     />
   </div>
-  <div class="mt-5 flex flex-row gap-x-10">
-    <div class="w-44">
-      <SelectInput
-        id="evolution-method"
-        label="Evolution Method"
-        bind:value={pokemon.evolution_method}
-        options={[
+  {#if !isNewPokemon}
+    <div class="mt-5 flex flex-row gap-x-10">
+      <div class="w-44">
+        <SelectInput
+          id="evolution-method"
+          label="Evolution Method"
+          bind:value={pokemon.evolution_method}
+          options={[
             { label: "No Change", value: "no_change" },
             { label: "Level Up", value: "level_up" },
             { label: "Other", value: "other" },
             { label: "Use Item", value: "item" },
           ]}
-      />
-    </div>
-    {#if pokemon.evolution_method === "item"}
-      <AutoComplete
-        label="Evolution Item"
-        bind:value={pokemon.evolution_item}
-        options={itemListOptions}
-        popupId="evolution-item-popup"
-        onSelection={(e) => {
-                pokemon.evolution_item = e.detail.label;
-              }}
-      />
-    {/if}
-    {#if pokemon.evolution_method === "level_up"}
-      <NumberInput
-        id="evolution-level"
-        bind:value={pokemon.evolution_level}
-        label="Evolution Level"
-        max={100}
-      />
-    {/if}
-    {#if pokemon.evolution_method === "other"}
-      <TextInput
-        id="evolution-other"
-        bind:value={pokemon.evolution_other}
-        label="Evolution Other"
-      />
-    {/if}
-    {#if pokemon.evolution_method !== "no_change"}
-      <div class="w-44">
-        <AutoComplete
-          label="Evolves To"
-          bind:value={pokemon.evolved_pokemon}
-          placeholder="Evolves To"
-          options={pokemonListOptions}
-          popupId="evolved-pokemon-popup"
-          onSelection={(e) => {
-              pokemon.evolved_pokemon = e.detail.label;
-            }}
         />
       </div>
-    {/if}
-  </div>
+      {#if pokemon.evolution_method === "item"}
+        <AutoComplete
+          label="Evolution Item"
+          bind:value={pokemon.evolution_item}
+          options={itemListOptions}
+          popupId="evolution-item-popup"
+          onSelection={(e) => {
+                pokemon.evolution_item = e.detail.label;
+              }}
+        />
+      {/if}
+      {#if pokemon.evolution_method === "level_up"}
+        <NumberInput
+          id="evolution-level"
+          bind:value={pokemon.evolution_level}
+          label="Evolution Level"
+          max={100}
+        />
+      {/if}
+      {#if pokemon.evolution_method === "other"}
+        <TextInput
+          id="evolution-other"
+          bind:value={pokemon.evolution_other}
+          label="Evolution Other"
+        />
+      {/if}
+      {#if pokemon.evolution_method !== "no_change"}
+        <div class="w-44">
+          <AutoComplete
+            label="Evolves To"
+            bind:value={pokemon.evolved_pokemon}
+            placeholder="Evolves To"
+            options={pokemonListOptions}
+            popupId="evolved-pokemon-popup"
+            onSelection={(e) => {
+              pokemon.evolved_pokemon = e.detail.label;
+            }}
+          />
+        </div>
+      {/if}
+    </div>
+  {/if}
   <p class="mt-10 text-lg">Stats</p>
   <div class="mb-2 mt-2 grid grid-cols-2 gap-x-10 gap-y-5">
     <NumberInput id="pokemon-hp" bind:value={pokemon.hp} label="HP" max={255} />

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,7 +8,7 @@ import type Database from "tauri-plugin-sql-api";
 import type { QueryResult } from "tauri-plugin-sql-api";
 import _ from "lodash";
 
-async function addMoves(
+export async function addMoves(
   moveAdditions: MoveSetChange[],
   pokemonId: number,
   database: Database,

--- a/src/routes/pokemon/+page.svelte
+++ b/src/routes/pokemon/+page.svelte
@@ -5,6 +5,7 @@ import PokemonPanel from "$lib/components/PokemonPanel.svelte";
 import { Tab, TabGroup, getToastStore } from "@skeletonlabs/skeleton";
 import { invoke } from "@tauri-apps/api/tauri";
 import { selectedWiki } from "../../store";
+import NewPokemonPanel from "$lib/components/NewPokemonPanel.svelte";
 
 const toastStore = getToastStore();
 
@@ -38,6 +39,7 @@ async function generatePokemonPagesInRange() {
   <Tab bind:group={tabSet} name="pokemon" value={0}>Pokemon</Tab>
   <Tab bind:group={tabSet} name="prepare-pokemon-data" value={1}>Generation</Tab
   >
+  <Tab bind:group={tabSet} name="new-pokemon" value={2}>Create New Pokemon</Tab>
   <svelte:fragment slot="panel">
     {#if tabSet === 0}
       <PokemonPanel />
@@ -68,6 +70,9 @@ async function generatePokemonPagesInRange() {
         onClick={generatePokemonPagesInRange}
         loading={loading}
       />
+    {/if}
+    {#if tabSet === 2}
+      <NewPokemonPanel />
     {/if}
   </svelte:fragment>
 </TabGroup>

--- a/src/store/pokemon.ts
+++ b/src/store/pokemon.ts
@@ -47,7 +47,7 @@ export type MoveSetChange = {
   secondaryMove: string;
 };
 
-type LearnMethod = "level-up" | "machine" | "tutor" | "egg";
+export type LearnMethod = "level-up" | "machine" | "tutor" | "egg";
 
 export enum Operation {
   ADD = "add",


### PR DESCRIPTION
Users now have the ability to document new pokemon specific to their ROM Hacks.

Users will be able to specify the pokemon's:
* sprite
* name
* dex number
* stats
* types
* abilities
* moveset

As a part of this feature, users will be able to copy moves from existing pokemon onto their new pokemon and modify the moveset accordingly. Having to add all moves from scratch would be tedious in certain cases.

Other change
- Found and fixed issue where defensive matchups weren't rendering for pokemon with a single type.