### PR TITLE
Feature/94 consolidate encounters on routes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,10 @@ jobs:
           releaseName: "WikiGen v__VERSION__"
           releaseBody: "
             Changelog:
-            \n- Fixed route encounter pokemon not linking to the corrent pokemon page.
+            \n- Consolidated Wild and Trainer Encounters onto a single page.
+            \n- Updated Design of both Wild and Trainer Encounters.
+            \n- Added ability to determine whether or not a route gets rendered.
+            \n- Fixed issue where ability flavor text wasn't being displayed properly
             "
           releaseDraft: false
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ And have those changes immediately reflect in the wiki.
 
 2. Download and install the application binary for your operating system.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > On Mac, when you try to open the app, you might get this popup message. "'WikiGen' cannot be opened because the developer cannot be verified."
 > The app is currently unsigned but I plan on signing it in the future. For now, just follow the below instructions once to get past it.
 > - Open Finder
-> - Ctrl + click the app 
+> - Ctrl + click the app
 > - Click Open
 > - You might get one more popup. Click open again.
 
@@ -36,7 +36,7 @@ And have those changes immediately reflect in the wiki.
 
 2. Fill out the fields as instructed and click the "Create Wiki" button.
 
-> [!TIP]  
+> [!TIP]
 > Use your github username to make deployment to github pages easier.
 > However, you can use a different name if you prefer to host it elsewhere
 
@@ -50,7 +50,7 @@ Navigate to the Wiki Testing page and follow the instructions to get the local s
 
 The app comes preloaded with data for all 1025 Pokemon. As of this release, you can modify a Pokemon's types, abilities, stats, evolution details, and movesets.
 
-> [!NOTE]  
+> [!NOTE]
 > The data is currently missing mega-evolutions, regional variants, and some minor forms.
 
 On the Pokemon page, find, edit, and save any entry. Saved changes will be immediately reflected in the wiki. Give it a go!
@@ -65,15 +65,15 @@ On the Pokemon page, find, edit, and save any entry. Saved changes will be immed
 
 Open the Game Routes page and create a new route, eg, Nimbasa City, or Route 1. Open the newly created route by clicking its box. All changes to wild encounters and trainer encounters will be reflected in the wiki.
 
-> [!TIP]  
-> You'll also see an option to "Modify Encounter Types." Use this to add all the environments where a player can encounter wild pokemon on a route. Eg. Grass, Tall-Grass, Surfing, Fishing, Cave, etc.
+> [!TIP]
+> You'll also see an option to "Modify Encounter Areas." Use this to add all the environments where a player can encounter wild pokemon on a route. Eg. Grass, Tall-Grass, Surfing, Fishing, Cave, etc.
 >
 > You can add as many as you wish.
 
 **Documenting Wild Encounters**
 
 1. Select the "Wild Encounters" tab. (You should be here by default)
-2. Fill in the encounter type, Pokemon, and Encounter rate and click save.
+2. Fill in the encounter area, Pokemon, and Encounter rate and click save.
 3. The new route and wild encounter should be reflected in the wiki.
 4. Do this for all wild pokemon on the route.
 
@@ -109,7 +109,7 @@ For some trainers, such as gym leaders, you may want a sprite.
 1. Click the three horizontal dots beside the trainer name and select Add sprite.
 2. Type in the name of a sprite, such as blue and click Set Sprite.
 
-> [!NOTE]  
+> [!NOTE]
 > All trainer sprites are taken from the [Pokemon Showdown Trainer Sprites](https://play.pokemonshowdown.com/sprites/trainers/) page.
 > You can peruse this site if you're not sure what sprite name to use.
 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikigen",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "wiki_gen"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "chrono",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiki_gen"
-version = "1.3.1"
+version = "1.4.0"
 description = "A Desktop Application to generate wikis for Pokemon Rom Hacks"
 authors = ["Akeem Allen"]
 license = ""

--- a/src-tauri/resources/generator_assets/starting_data/routes.json
+++ b/src-tauri/resources/generator_assets/starting_data/routes.json
@@ -1,6 +1,6 @@
 {
   "routes": {},
-  "encounter_types": [
+  "encounter_areas": [
     "grass",
     "cave",
     "desert",

--- a/src-tauri/resources/generator_assets/starting_data/routes.json
+++ b/src-tauri/resources/generator_assets/starting_data/routes.json
@@ -1,4 +1,12 @@
 {
-    "routes": {},
-    "encounter_types": ["grass-normal"]
+  "routes": {},
+  "encounter_types": [
+    "grass",
+    "cave",
+    "desert",
+    "surf",
+    "fishing",
+    "dive",
+    "snow"
+  ]
 }

--- a/src-tauri/resources/generator_assets/stylesheets/extra.css
+++ b/src-tauri/resources/generator_assets/stylesheets/extra.css
@@ -51,7 +51,7 @@
 
 .trainer-pokemon-card {
   display: grid;
-  grid-template-rows: 1.5fr 1fr;
+  grid-template-rows: 2fr 1fr;
   grid-template-columns: 1fr 1fr;
   border: 1px solid #eef4ff;
   border-radius: 10px;
@@ -61,13 +61,18 @@
   row-gap: 0.5rem;
 }
 
+.trainer-pokemon-image-name-container {
+  display: block;
+  text-align: center;
+}
+
 .trainer-pokemon-name-level-container {
-  display: grid;
-  grid-template-columns: 3fr 1fr;
+  display: flex;
+  justify-content: space-evenly;
   background-color: white;
-  justify-content: space-between;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
+  font-size: 12px;
   border-radius: 10px;
   padding: 2px;
   align-items: center;
@@ -97,5 +102,5 @@
   justify-content: center;
   background-color: #fff;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  border-radius: 5px;
+  border-radius: 10px;
 }

--- a/src-tauri/resources/generator_assets/stylesheets/extra.css
+++ b/src-tauri/resources/generator_assets/stylesheets/extra.css
@@ -32,3 +32,70 @@
   border: 1px solid #737373;
   border-color: rgba(0, 0, 0, 0.15);
 }
+
+.trainer-pokemon-container {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  @media (min-width: 768px) {
+    grid-template-columns: 1fr 1fr;
+  }
+  @media (min-width: 1100px) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.trainer-pokemon-container @media (max-width: 768px) {
+  grid-template-columns: 1fr;
+}
+
+.trainer-pokemon-card {
+  display: grid;
+  grid-template-rows: 1.5fr 1fr;
+  grid-template-columns: 1fr 1fr;
+  border: 1px solid #eef4ff;
+  border-radius: 10px;
+  padding: 0.5rem;
+  background-color: #eef4ff;
+  min-width: 250px;
+  row-gap: 0.5rem;
+}
+
+.trainer-pokemon-name-level-container {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  background-color: white;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 10px;
+  padding: 2px;
+  align-items: center;
+}
+
+.trainer-pokemon-attributes {
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.5rem;
+  text-align: center;
+  align-items: center;
+  grid-column: 2/2;
+}
+
+.trainer-pokemon-moveset {
+  display: grid;
+  grid-column: 1/3;
+  grid-template-rows: 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.trainer-pokemon-move {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+}

--- a/src-tauri/resources/generator_assets/templates/route_page_template.md
+++ b/src-tauri/resources/generator_assets/templates/route_page_template.md
@@ -1,0 +1,9 @@
+{{route_name}}
+
+{{route_image}}
+
+{{wild_encounter_tab}}
+    {{wild_encounters}}
+
+{{trainer_encounter_tab}}
+    {{trainer_encounters}}

--- a/src-tauri/resources/generator_assets/templates/route_page_template.md
+++ b/src-tauri/resources/generator_assets/templates/route_page_template.md
@@ -4,4 +4,4 @@
 {{wild_encounters}}
 
 {{trainer_encounter_tab}}
-    {{trainer_encounters}}
+{{trainer_encounters}}

--- a/src-tauri/resources/generator_assets/templates/route_page_template.md
+++ b/src-tauri/resources/generator_assets/templates/route_page_template.md
@@ -1,5 +1,3 @@
-{{route_name}}
-
 {{route_image}}
 
 {{wild_encounter_tab}}

--- a/src-tauri/resources/generator_assets/templates/route_page_template.md
+++ b/src-tauri/resources/generator_assets/templates/route_page_template.md
@@ -1,7 +1,7 @@
 {{route_image}}
 
 {{wild_encounter_tab}}
-    {{wild_encounters}}
+{{wild_encounters}}
 
 {{trainer_encounter_tab}}
     {{trainer_encounters}}

--- a/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
+++ b/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
@@ -1,7 +1,7 @@
 <div class="trainer-pokemon-card">
   <div style="display: grid; row-gap: 0.5rem">
     <img src="../../img/pokemon/{{pokemon_name}}.png" alt={{pokemon_name}} style="border-radius: 10px; background-color: #fff; justify-self: center;"/>
-    <div style="display: flex; flex-direction: row; background-color: white; justify-content: space-between; border-radius: 10px; padding:2px; align-items: center;">
+    <div style="display: grid; grid-template-columns: 3fr 1fr; background-color: white; justify-content: space-between; border-radius: 10px; padding:2px; align-items: center;">
       <a href="/route-testing/pokemon/{{page_title}}">{{cap_pokemon_name}}</a>
       Lv {{level}}
     </div>

--- a/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
+++ b/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
@@ -8,8 +8,8 @@
   </div>
   <div class="trainer-pokemon-attributes">
     <div>
-      <img src="../../img/types/normal.png" alt=eevee style="width: 50px;"/>
-      <img src="../../img/types/water.png" alt=eevee style="width: 50px;"/>
+      {{type_one}}
+      {{type_two}}
     </div>
     <div>
       <p style="margin: 0px; font-size: 10px;">Ability:</p>

--- a/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
+++ b/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
@@ -1,5 +1,5 @@
 <div class="trainer-pokemon-card">
-  <div style="display: grid; row-gap: 0.5rem">
+  <div class="trainer-pokemon-image-name-container">
     <img src="../../img/pokemon/{{pokemon_name}}.png" alt={{pokemon_name}} style="border-radius: 10px; background-color: #fff; justify-self: center;"/>
     <div class="trainer-pokemon-name-level-container">
       <a href="/route-testing/pokemon/{{page_title}}">{{cap_pokemon_name}}</a>

--- a/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
+++ b/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
@@ -1,0 +1,36 @@
+<div class="trainer-pokemon-card">
+  <div style="display: grid; row-gap: 0.5rem">
+    <img src="../../img/pokemon/{{pokemon_name}}.png" alt={{pokemon_name}} style="border-radius: 10px; background-color: #fff; justify-self: center;"/>
+    <div style="display: flex; flex-direction: row; background-color: white; justify-content: space-between; border-radius: 10px; padding:2px;">
+      <a href="/route-testing/pokemon/{{page_title}}">{{cap_pokemon_name}}</a>
+      Lv {{level}}
+    </div>
+  </div>
+  <div class="trainer-pokemon-attributes">
+    <div>
+      <img src="../../img/types/normal.png" alt=eevee style="width: 50px;"/>
+      <img src="../../img/types/water.png" alt=eevee style="width: 50px;"/>
+    </div>
+    <div>
+      <p style="margin: 0px; font-size: 10px;">Ability:</p>
+      {{ability}}
+    </div>
+    <div>
+      <p style="margin: 0px; font-size: 10px;">Nature:</p>
+      {{nature}}
+    </div>
+    <div>
+      <p style="margin: 0px; font-size: 10px;">Held Item:</p>
+      <div style="display: flex; align-items: center">
+        {{item_image}}
+        {{item_name}}
+      </div>
+    </div>
+  </div>
+  <div class="trainer-pokemon-moveset">
+    {{move_1}}
+    {{move_2}}
+    {{move_3}}
+    {{move_4}}
+  </div>
+</div>

--- a/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
+++ b/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
@@ -1,7 +1,7 @@
 <div class="trainer-pokemon-card">
   <div style="display: grid; row-gap: 0.5rem">
     <img src="../../img/pokemon/{{pokemon_name}}.png" alt={{pokemon_name}} style="border-radius: 10px; background-color: #fff; justify-self: center;"/>
-    <div style="display: grid; grid-template-columns: 3fr 1fr; background-color: white; justify-content: space-between; border-radius: 10px; padding:2px; align-items: center;">
+    <div class="trainer-pokemon-name-level-container">
       <a href="/route-testing/pokemon/{{page_title}}">{{cap_pokemon_name}}</a>
       Lv {{level}}
     </div>

--- a/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
+++ b/src-tauri/resources/generator_assets/templates/trainer_pokemon_template.md
@@ -1,7 +1,7 @@
 <div class="trainer-pokemon-card">
   <div style="display: grid; row-gap: 0.5rem">
     <img src="../../img/pokemon/{{pokemon_name}}.png" alt={{pokemon_name}} style="border-radius: 10px; background-color: #fff; justify-self: center;"/>
-    <div style="display: flex; flex-direction: row; background-color: white; justify-content: space-between; border-radius: 10px; padding:2px;">
+    <div style="display: flex; flex-direction: row; background-color: white; justify-content: space-between; border-radius: 10px; padding:2px; align-items: center;">
       <a href="/route-testing/pokemon/{{page_title}}">{{cap_pokemon_name}}</a>
       Lv {{level}}
     </div>

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,9 +14,7 @@ use helpers::json_conversion::{
 };
 use helpers::mkdocs_process::{check_process_status, kill_mkdocs_process, spawn_mkdocs_process};
 use page_generators::ability_page::generate_ability_page;
-use page_generators::game_routes::{
-    generate_route_pages_with_handle, generate_single_route_page_with_handle,
-};
+use page_generators::game_routes::generate_route_pages_with_handle;
 use page_generators::item_page::generate_item_page;
 use page_generators::nature_page::generate_nature_page;
 use page_generators::pokemon_pages::generate_pokemon_pages_from_list;
@@ -58,7 +56,6 @@ fn main() {
             generate_pokemon_pages_from_list,
             download_pokemon_sprites,
             generate_route_pages_with_handle,
-            generate_single_route_page_with_handle,
             backup_wiki,
             generate_item_page,
             generate_nature_page,

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -419,7 +419,14 @@ fn generate_trainer_entry(
                 .clone()
                 .replace("{{pokemon_name}}", &pokemon.name)
                 .replace("{{cap_pokemon_name}}", &capitalize(&pokemon.name))
-                .replace("{{page_title}}", &format!("{}", pokemon.name))
+                .replace(
+                    "{{page_title}}",
+                    &format!(
+                        "{}-{}",
+                        get_pokemon_dex_formatted_name(u32::try_from(pokemon.id).unwrap()),
+                        pokemon.name
+                    ),
+                )
                 .replace("{{level}}", pokemon.level.to_string().as_str())
                 .replace("{{ability}}", &ability)
                 .replace("{{nature}}", &nature)

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -233,39 +233,34 @@ fn create_encounter_table(
     let mut markdown_encounters = String::new();
     for (encounter_type, pokemon_encounter_list) in encounters {
         let mut pokemon_entries = String::new();
-        for (index, pokemon) in pokemon_encounter_list.iter().enumerate() {
-            let mut entry = format!("| {} ", get_markdown_entry_for_pokemon(wiki_name, &pokemon));
-            // It's possible for a single route to have more than 6 pokemon
-            // We want break the entries into a new line at that 6th position.
-            if index != 0 && index % 6 == 0 {
-                entry = format!(
-                    "\n| | {} ",
-                    get_markdown_entry_for_pokemon(wiki_name, &pokemon)
-                );
-            }
+        for pokemon in pokemon_encounter_list.iter() {
+            let entry = format!(
+                "<div style=\"display: grid; justify-items: center\">
+                    {}
+                </div>",
+                get_markdown_entry_for_pokemon(wiki_name, &pokemon)
+            );
             pokemon_entries.push_str(&entry);
         }
-        pokemon_entries.push_str("|");
 
         let encounter_type_entry = match encounter_areas_levels.get(&encounter_type.clone()) {
             Some(area_level) => format!(
-                "{}<br/> Lv. {}",
+                "{} Lv. {}",
                 capitalize_and_remove_hyphens(&encounter_type),
                 area_level
             ),
             None => encounter_type.to_string(),
         };
-        let encounter_entry = format!("| {} {}\n", encounter_type_entry, pokemon_entries);
+        let encounter_area = capitalize_and_remove_hyphens(&encounter_type_entry);
+        let encounters = format!(
+            "<div style=\"display: grid; grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;\">{}</div>",
+            pokemon_entries
+        );
+        let encounter_entry = format!("\n\n\t???+ note \"{}\"\n\t\t{}", encounter_area, encounters);
         markdown_encounters.push_str(&encounter_entry);
     }
 
-    return format!(
-        "| Area | Pokemon | | | | | |
-        | :--: | :--: | :--: | :--: | :--: | :--: | :--: |
-        {}
-        ",
-        markdown_encounters
-    );
+    return markdown_encounters;
 }
 
 fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo>) -> String {
@@ -301,7 +296,7 @@ fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo
 fn get_markdown_entry_for_pokemon(wiki_name: &str, pokemon: &WildEncounter) -> String {
     let dex_number_file_name = get_pokemon_dex_formatted_name(pokemon.id.try_into().unwrap());
     return format!(
-        "![{}](../../img/pokemon/{}.png)<br/> [{}](/{}/pokemon/{})<br/> {}%",
+        "![{}](../../img/pokemon/{}.png) [{}](/{}/pokemon/{}) {}%",
         pokemon.name,
         pokemon.name,
         capitalize(&pokemon.name),

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -18,7 +18,7 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Routes {
     pub routes: IndexMap<String, RouteProperties>,
-    pub encounter_types: Vec<String>,
+    pub encounter_areas: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -55,7 +55,7 @@ pub struct WildEncounter {
     pub id: usize,
     pub name: String,
     pub encounter_rate: usize,
-    pub encounter_type: String,
+    pub encounter_area: String,
     pub route: String,
     pub special_note: String,
 }
@@ -231,7 +231,7 @@ fn generate_wild_encounter_markdown(
     encounter_areas_levels: &IndexMap<String, String>,
 ) -> String {
     let mut markdown_encounters = String::new();
-    for (encounter_type, pokemon_encounter_list) in encounters {
+    for (encounter_area, pokemon_encounter_list) in encounters {
         let mut pokemon_entries = String::new();
         for pokemon in pokemon_encounter_list.iter() {
             let entry = format!(
@@ -243,21 +243,21 @@ fn generate_wild_encounter_markdown(
             pokemon_entries.push_str(&entry);
         }
 
-        let encounter_type_entry = match encounter_areas_levels.get(&encounter_type.clone()) {
+        let encounter_area_entry = match encounter_areas_levels.get(&encounter_area.clone()) {
             Some(area_level) => {
                 if area_level.is_empty() {
-                    encounter_type.to_string()
+                    encounter_area.to_string()
                 } else {
                     format!(
                         "{} Lv. {}",
-                        capitalize_and_remove_hyphens(&encounter_type),
+                        capitalize_and_remove_hyphens(&encounter_area),
                         area_level
                     )
                 }
             }
-            None => encounter_type.to_string(),
+            None => encounter_area.to_string(),
         };
-        let encounter_area = capitalize_and_remove_hyphens(&encounter_type_entry);
+        let encounter_area = capitalize_and_remove_hyphens(&encounter_area_entry);
         let encounters = format!(
             "<div style=\"display: grid; grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;\">{}</div>",
             pokemon_entries

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -41,6 +41,7 @@ pub struct TrainerInfo {
 pub struct TrainerPokemon {
     pub id: usize,
     pub unique_id: String,
+    pub types: Vec<String>,
     pub name: String,
     pub level: usize,
     pub moves: Vec<String>,
@@ -400,7 +401,7 @@ fn generate_trainer_entry(
                 pokemon.item, pokemon.item
             ))
         } else {
-            item_image.push_str("-");
+            item_image.push_str("<div></div>");
         }
         let mut ability = String::new();
         if pokemon.ability != "" {
@@ -414,6 +415,25 @@ fn generate_trainer_entry(
         } else {
             nature = "-".to_string();
         }
+
+        let type_one = format!(
+            "<img src=\"../../img/types/{}.png\" alt={} style=\"width: 50px;\"/>",
+            pokemon.types.get(0).unwrap(),
+            pokemon.types.get(0).unwrap()
+        );
+
+        let type_two: String;
+
+        if pokemon.types.len() > 1 {
+            type_two = format!(
+                "<img src=\"../../img/types/{}.png\" alt={} style=\"width: 50px;\"/>",
+                pokemon.types.get(1).unwrap(),
+                pokemon.types.get(1).unwrap()
+            );
+        } else {
+            type_two = "<div></div>".to_string();
+        }
+
         unsafe {
             pokemon_entry = TRAINER_POKEMON_TEMPLATE
                 .clone()
@@ -431,6 +451,8 @@ fn generate_trainer_entry(
                 .replace("{{ability}}", &ability)
                 .replace("{{nature}}", &nature)
                 .replace("{{item_image}}", &item_image)
+                .replace("{{type_one}}", &type_one)
+                .replace("{{type_two}}", &type_two)
                 .replace("{{item_name}}", &evaluate_attribute(&pokemon.item))
                 .replace("{{move_1}}", &extract_move(pokemon.moves.get(0)))
                 .replace("{{move_2}}", &extract_move(pokemon.moves.get(1)))

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -196,12 +196,12 @@ fn generate_route_page_from_template(
 
     if !route_properties.wild_encounters.is_empty() {
         wild_encounter_tab.push_str("=== \"Wild Encounters\"");
-        let encounter_table = create_encounter_table(
+        let wild_encounter_markdown = generate_wild_encounter_markdown(
             wiki_name,
             &route_properties.wild_encounters,
             &route_properties.wild_encounter_area_levels,
         );
-        wild_encounters.push_str(&encounter_table);
+        wild_encounters.push_str(&wild_encounter_markdown);
     }
 
     let mut trainer_encounter_tab = String::new();
@@ -225,7 +225,7 @@ fn generate_route_page_from_template(
     return result;
 }
 
-fn create_encounter_table(
+fn generate_wild_encounter_markdown(
     wiki_name: &str,
     encounters: &IndexMap<String, Vec<WildEncounter>>,
     encounter_areas_levels: &IndexMap<String, String>,
@@ -244,11 +244,17 @@ fn create_encounter_table(
         }
 
         let encounter_type_entry = match encounter_areas_levels.get(&encounter_type.clone()) {
-            Some(area_level) => format!(
-                "{} Lv. {}",
-                capitalize_and_remove_hyphens(&encounter_type),
-                area_level
-            ),
+            Some(area_level) => {
+                if area_level.is_empty() {
+                    encounter_type.to_string()
+                } else {
+                    format!(
+                        "{} Lv. {}",
+                        capitalize_and_remove_hyphens(&encounter_type),
+                        area_level
+                    )
+                }
+            }
             None => encounter_type.to_string(),
         };
         let encounter_area = capitalize_and_remove_hyphens(&encounter_type_entry);

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -292,7 +292,7 @@ fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo
     for (name, trainer_info) in trainers {
         if trainer_info.versions.is_empty() {
             let trainer_entry = format!(
-                "<div style=\"display: grid; grid-template-columns: 1fr 1fr 1fr;column-gap: 1rem\">\n{}</div>",
+                "<div style=\"display: grid; grid-template-columns: 1fr 1fr 1fr;gap: 1rem\">\n{}</div>",
                 generate_trainer_entry(wiki_name, name, trainer_info, "")
             );
             markdown_trainers.push_str(&format!(

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -291,14 +291,15 @@ fn generate_wild_encounter_markdown(
 fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo>) -> String {
     let mut markdown_trainers = String::new();
     for (name, trainer_info) in trainers {
+        let trainer_sprite = get_trainer_sprite(name, &trainer_info.sprite);
         if trainer_info.versions.is_empty() {
             let trainer_entry = format!(
                 "<div style=\"display: grid; grid-template-columns: 1fr 1fr 1fr;gap: 1rem\">\n{}</div>",
                 generate_trainer_entry(wiki_name, name, trainer_info, "")
             );
             markdown_trainers.push_str(&format!(
-                "\n\n\t???+ note \"{}\"\n\t\t{}",
-                name, trainer_entry
+                "\n\t{}\n\t???+ note \"{}\"\n\t\t{}",
+                trainer_sprite, name, trainer_entry
             ));
         } else {
             for version in &trainer_info.versions {
@@ -354,11 +355,11 @@ fn get_markdown_entry_for_trainer_pokemon(wiki_name: &str, pokemon: &TrainerPoke
 
 fn get_trainer_sprite(name: &str, sprite: &str) -> String {
     if sprite == "".to_string() {
-        return name.to_string();
+        return "".to_string();
     }
     return format!(
-        "{}<br/> ![{}](https://play.pokemonshowdown.com/sprites/trainers/{}.png)",
-        name, name, sprite
+        "![{}](https://play.pokemonshowdown.com/sprites/trainers/{}.png)",
+        name, sprite
     );
 }
 
@@ -366,7 +367,7 @@ fn extract_move(_move: Option<&String>) -> String {
     match _move.clone() {
         Some(_move) => format!(
             "<div class=\"trainer-pokemon-move\">{}</div>",
-            _move.to_string()
+            capitalize_and_remove_hyphens(_move)
         ),
         None => return "<div class=\"trainer-pokemon-move\">-</div>".to_string(),
     }
@@ -375,7 +376,7 @@ fn extract_move(_move: Option<&String>) -> String {
 fn evaluate_attribute(attribute: &str) -> String {
     match attribute {
         "" => return "-".to_string(),
-        _ => return attribute.to_string(),
+        _ => return capitalize_and_remove_hyphens(attribute),
     }
 }
 
@@ -405,13 +406,13 @@ fn generate_trainer_entry(
         }
         let mut ability = String::new();
         if pokemon.ability != "" {
-            ability = pokemon.ability.to_string();
+            ability = capitalize_and_remove_hyphens(&pokemon.ability);
         } else {
             ability = "-".to_string();
         }
         let mut nature = String::new();
         if pokemon.nature != "" {
-            nature = pokemon.nature.to_string();
+            nature = capitalize_and_remove_hyphens(&pokemon.nature);
         } else {
             nature = "-".to_string();
         }

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -301,14 +301,18 @@ fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo
 
 fn get_markdown_entry_for_pokemon(wiki_name: &str, pokemon: &WildEncounter) -> String {
     let dex_number_file_name = get_pokemon_dex_formatted_name(pokemon.id.try_into().unwrap());
+    let encounter_rate = match pokemon.encounter_rate {
+        0 => "".to_string(),
+        _ => format!("{}%", &pokemon.encounter_rate),
+    };
     return format!(
-        "![{}](../../img/pokemon/{}.png) [{}](/{}/pokemon/{}) {}%",
+        "![{}](../../img/pokemon/{}.png) [{}](/{}/pokemon/{}) {}",
         pokemon.name,
         pokemon.name,
         capitalize(&pokemon.name),
         wiki_name,
         format!("{}-{}", dex_number_file_name, pokemon.name),
-        pokemon.encounter_rate
+        encounter_rate
     );
 }
 

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -294,7 +294,7 @@ fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo
         let trainer_sprite = get_trainer_sprite(name, &trainer_info.sprite);
         if trainer_info.versions.is_empty() {
             let trainer_entry = format!(
-                "<div style=\"display: grid; grid-template-columns: 1fr 1fr 1fr;gap: 1rem\">\n{}</div>",
+                "<div class=\"trainer-pokemon-container\">\n{}</div>",
                 generate_trainer_entry(wiki_name, name, trainer_info, "")
             );
             markdown_trainers.push_str(&format!(

--- a/src-tauri/src/page_generators/game_routes.rs
+++ b/src-tauri/src/page_generators/game_routes.rs
@@ -292,15 +292,13 @@ fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo
     let mut markdown_trainers = String::new();
     for (name, trainer_info) in trainers {
         let trainer_sprite = get_trainer_sprite(name, &trainer_info.sprite);
+        let mut trainer_entry: String = String::new();
+
         if trainer_info.versions.is_empty() {
-            let trainer_entry = format!(
+            trainer_entry = format!(
                 "<div class=\"trainer-pokemon-container\">\n{}</div>",
                 generate_trainer_entry(wiki_name, name, trainer_info, "")
             );
-            markdown_trainers.push_str(&format!(
-                "\n\t{}\n\t???+ note \"{}\"\n\t\t{}",
-                trainer_sprite, name, trainer_entry
-            ));
         } else {
             for version in &trainer_info.versions {
                 // This is to prevent rendering a trainer version that doesn't have a pokemon
@@ -315,11 +313,19 @@ fn create_trainer_table(wiki_name: &str, trainers: &IndexMap<String, TrainerInfo
                 if !version_has_one_pokemon {
                     continue;
                 }
-                markdown_trainers.push_str(&format!("\n=== \"{}\"", version));
-                let trainer_entry = generate_trainer_entry(wiki_name, name, trainer_info, version);
-                markdown_trainers.push_str(&format!("\t{}", trainer_entry));
+
+                let version_title = format!("\n\n\t\t=== \"{}\"", version);
+                let entry = format!(
+                    "\t<div class=\"trainer-pokemon-container\">\n{}</div>",
+                    generate_trainer_entry(wiki_name, name, trainer_info, version)
+                );
+                trainer_entry.push_str(&format!("{}\n\t\t{}", version_title, entry));
             }
         }
+        markdown_trainers.push_str(&format!(
+            "\n\t{}\n\t???+ note \"{}\"\n\t\t{}",
+            trainer_sprite, name, trainer_entry
+        ));
     }
     return format!("{}", markdown_trainers);
 }
@@ -460,9 +466,13 @@ fn generate_trainer_entry(
                 .replace("{{move_3}}", &extract_move(pokemon.moves.get(2)))
                 .replace("{{move_4}}", &extract_move(pokemon.moves.get(3)));
         };
+        let mut tabs = "\t\t";
+        if !version.is_empty() {
+            tabs = "\t\t\t\t";
+        }
         let indented_lines: Vec<String> = pokemon_entry
             .lines()
-            .map(|line| format!("\t\t{}", line))
+            .map(|line| format!("{}{}", tabs, line))
             .collect();
         let indented_pokemon_entry = indented_lines.join("\n");
 

--- a/src-tauri/src/page_generators/pokemon_page_generator_functions.rs
+++ b/src-tauri/src/page_generators/pokemon_page_generator_functions.rs
@@ -261,7 +261,7 @@ pub fn create_locations_table(wild_encounters: Vec<WildEncounter>) -> String {
         let table_entry = format!(
             "\t| {} | {} | {} | {} |\n",
             encounter.route,
-            capitalize_and_remove_hyphens(&encounter.encounter_type),
+            capitalize_and_remove_hyphens(&encounter.encounter_area),
             encounter.encounter_rate,
             encounter.special_note
         );

--- a/src-tauri/src/page_generators/pokemon_pages.rs
+++ b/src-tauri/src/page_generators/pokemon_pages.rs
@@ -334,7 +334,7 @@ pub fn generate_page_from_template(
     if pokemon.ability_1.is_some() {
         ability_1.push_str(
             format!(
-                "<a href='' title='{}'>{}</a>",
+                "<a href='' title=\"{}\">{}</a>",
                 &pokemon.a1_effect.as_ref().unwrap(),
                 capitalize(&pokemon.ability_1.as_ref().unwrap())
             )

--- a/src-tauri/src/wiki_preparation/yaml_declaration.rs
+++ b/src-tauri/src/wiki_preparation/yaml_declaration.rs
@@ -86,6 +86,7 @@ pub fn get_yaml(
             MarkdownExtension::String("attr_list".to_string()),
             MarkdownExtension::String("pymdownx.snippets".to_string()),
             MarkdownExtension::String("pymdownx.superfences".to_string()),
+            MarkdownExtension::String("pymdownx.details".to_string()),
             MarkdownExtension::PymdownxTaskList(PymdownxTaskList {
                 custom_checkbox: true,
             }),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "WikiGen",
-    "version": "1.3.1"
+    "version": "1.4.0"
   },
   "tauri": {
     "allowlist": {

--- a/src/lib/components/NewPokemonPanel.svelte
+++ b/src/lib/components/NewPokemonPanel.svelte
@@ -166,6 +166,7 @@
           res.lastInsertId,
           newPokemon.dex_number,
           newPokemon.name,
+          newPokemon.types,
         ]);
 
         toastStore.trigger({

--- a/src/lib/components/PokemonLocationTab.svelte
+++ b/src/lib/components/PokemonLocationTab.svelte
@@ -66,6 +66,23 @@
   $: rows = handler.getRows();
   $: rowsPerPage = handler.getRowsPerPage();
 
+  async function generateRoutePage(routeName: string) {
+    invoke("generate_route_pages_with_handle", {
+      wikiName: $selectedWiki.name,
+      routeNames: [routeName],
+    })
+      .then(() => {
+        toastStore.trigger({
+          message: "Changes saved successfully",
+          timeout: 3000,
+          background: "variant-filled-success",
+        });
+      })
+      .catch((e) => {
+        console.error(e);
+      });
+  }
+
   async function addPokemonToLocation() {
     newLocation.id = pokemonId;
     newLocation.name = pokemonName;
@@ -111,20 +128,7 @@
       JSON.stringify($routes),
       { dir: BaseDirectory.AppData },
     ).then(() => {
-      invoke("generate_single_route_page_with_handle", {
-        wikiName: $selectedWiki.name,
-        routeName: location.route,
-      })
-        .then(() => {
-          toastStore.trigger({
-            message: "Changes saved successfully",
-            timeout: 3000,
-            background: "variant-filled-success",
-          });
-        })
-        .catch((e) => {
-          console.error(e);
-        });
+      generateRoutePage(location.route);
       pokemonLocations = [...pokemonLocations, { ...location }];
       addLocationModalOpen = false;
       newLocation = {
@@ -157,20 +161,7 @@
       JSON.stringify($routes),
       { dir: BaseDirectory.AppData },
     ).then(() => {
-      invoke("generate_single_route_page_with_handle", {
-        wikiName: $selectedWiki.name,
-        routeName: location.route,
-      })
-        .then(() => {
-          toastStore.trigger({
-            message: "Changes saved successfully",
-            timeout: 3000,
-            background: "variant-filled-success",
-          });
-        })
-        .catch((e) => {
-          console.error(e);
-        });
+      generateRoutePage(location.route);
       let updatedLocations = [...pokemonLocations];
       let locationIndex = updatedLocations.findIndex(
         (loc) =>
@@ -224,20 +215,7 @@
       JSON.stringify($routes),
       { dir: BaseDirectory.AppData },
     ).then(() => {
-      invoke("generate_single_route_page_with_handle", {
-        wikiName: $selectedWiki.name,
-        routeName,
-      })
-        .then(() => {
-          toastStore.trigger({
-            message: "Changes saved successfully",
-            timeout: 3000,
-            background: "variant-filled-success",
-          });
-        })
-        .catch((e) => {
-          console.error(e);
-        });
+      generateRoutePage(routeName);
       let updatedLocations: WildEncounter[] = [];
       for (let location of pokemonLocations) {
         if (location.route !== routeName) {

--- a/src/lib/components/PokemonLocationTab.svelte
+++ b/src/lib/components/PokemonLocationTab.svelte
@@ -27,7 +27,7 @@
   let newLocation: WildEncounter = {
     id: 0,
     name: "",
-    encounter_type: "",
+    encounter_area: "",
     encounter_rate: 0,
     route: "",
     special_note: "",
@@ -36,7 +36,7 @@
   let locationToEdit: WildEncounter = {
     id: 0,
     name: "",
-    encounter_type: "",
+    encounter_area: "",
     encounter_rate: 0,
     route: "",
     special_note: "",
@@ -47,9 +47,9 @@
     value: route,
   }));
 
-  let encounterTypeOptions = $routes.encounter_types.map((encounter_type) => ({
-    label: encounter_type,
-    value: encounter_type,
+  let encounterTypeOptions = $routes.encounter_areas.map((encounter_area) => ({
+    label: encounter_area,
+    value: encounter_area,
   }));
 
   const rowsPerPageOptions = [
@@ -99,7 +99,7 @@
 
     if (
       $routes.routes[location.route].wild_encounters[
-        location.encounter_type
+        location.encounter_area
       ]?.find((encounter) => encounter.name === location.name)
     ) {
       toastStore.trigger({
@@ -111,15 +111,15 @@
 
     $routes.routes[location.route].wild_encounters = {
       ...$routes.routes[location.route].wild_encounters,
-      [location.encounter_type]: [
+      [location.encounter_area]: [
         ...($routes.routes[location.route].wild_encounters[
-          location.encounter_type
+          location.encounter_area
         ] ?? []),
         location,
       ],
     };
 
-    $routes.routes[location.route].wild_encounters[location.encounter_type]
+    $routes.routes[location.route].wild_encounters[location.encounter_area]
       .sort((a, b) => a.encounter_rate - b.encounter_rate)
       .reverse();
 
@@ -134,7 +134,7 @@
       newLocation = {
         id: 0,
         name: "",
-        encounter_type: "",
+        encounter_area: "",
         encounter_rate: 0,
         route: "",
         special_note: "",
@@ -146,13 +146,13 @@
     let location = cloneDeep(locationToEdit);
 
     let index = $routes.routes[location.route].wild_encounters[
-      location.encounter_type
+      location.encounter_area
     ].findIndex((encounter) => encounter.id === location.id);
     $routes.routes[location.route].wild_encounters[
-      location.encounter_type
+      location.encounter_area
     ].splice(index, 1, cloneDeep(location));
 
-    $routes.routes[location.route].wild_encounters[location.encounter_type]
+    $routes.routes[location.route].wild_encounters[location.encounter_area]
       .sort((a, b) => a.encounter_rate - b.encounter_rate)
       .reverse();
 
@@ -166,7 +166,7 @@
       let locationIndex = updatedLocations.findIndex(
         (loc) =>
           loc.route === location.route &&
-          loc.encounter_type === location.encounter_type,
+          loc.encounter_area === location.encounter_area,
       );
       console.log(locationIndex);
       updatedLocations[locationIndex] = cloneDeep(location);
@@ -176,7 +176,7 @@
       locationToEdit = {
         id: 0,
         name: "",
-        encounter_type: "",
+        encounter_area: "",
         encounter_rate: 0,
         route: "",
         special_note: "",
@@ -222,7 +222,7 @@
           updatedLocations.push(location);
           continue;
         }
-        if (location.encounter_type !== encounterType) {
+        if (location.encounter_area !== encounterType) {
           updatedLocations.push(location);
           continue;
         }
@@ -245,8 +245,8 @@
     }}
   />
   <SelectInput
-    bind:value={newLocation.encounter_type}
-    label="Encounter Type"
+    bind:value={newLocation.encounter_area}
+    label="Encounter Area"
     options={encounterTypeOptions}
   />
   <NumberInput
@@ -264,7 +264,7 @@
     title="Add Location"
     disabled={newLocation.route === "" ||
       newLocation.encounter_rate <= 0 ||
-      newLocation.encounter_type === ""}
+      newLocation.encounter_area === ""}
     onClick={addPokemonToLocation}
   />
 </BaseModal>
@@ -283,8 +283,8 @@
     }}
   />
   <SelectInput
-    bind:value={locationToEdit.encounter_type}
-    label="Encounter Type"
+    bind:value={locationToEdit.encounter_area}
+    label="Encounter Area"
     disabled={true}
     options={encounterTypeOptions}
   />
@@ -303,7 +303,7 @@
     title="Save Changes"
     disabled={locationToEdit.route === "" ||
       locationToEdit.encounter_rate <= 0 ||
-      locationToEdit.encounter_type === ""}
+      locationToEdit.encounter_area === ""}
     onClick={editPokemonLocation}
   />
 </BaseModal>
@@ -332,7 +332,7 @@
     <thead>
       <tr class="bg-white">
         <ThSort {handler} orderBy="route">Route</ThSort>
-        <ThSort {handler} orderBy="encounter_type">Encounter Type</ThSort>
+        <ThSort {handler} orderBy="encounter_area">Encounter Area</ThSort>
         <ThSort {handler} orderBy="encounter_rate">Encounter Rate</ThSort>
         <ThSort {handler} orderBy="special_note">Special Note</ThSort>
       </tr>
@@ -341,7 +341,7 @@
       {#each $rows as row}
         <tr>
           <td>{row.route}</td>
-          <td>{row.encounter_type}</td>
+          <td>{row.encounter_area}</td>
           <td>{row.encounter_rate}</td>
           <td>{row.special_note}</td>
           <td
@@ -356,7 +356,7 @@
           <td
             class="w-5 rounded-sm hover:cursor-pointer hover:bg-gray-300"
             on:click={() => {
-              deletePokemonFromLocation(row.route, row.encounter_type, row.id);
+              deletePokemonFromLocation(row.route, row.encounter_area, row.id);
             }}
           >
             <IconTrash size={18} class="text-gray-500" />

--- a/src/lib/components/SelectInput.svelte
+++ b/src/lib/components/SelectInput.svelte
@@ -7,7 +7,7 @@
   };
   export let id = "";
   export let label = "";
-  export let value: string | undefined | null | number = "";
+  export let value: string | undefined | null | boolean | number = "";
   export let options: Option[] = [];
   export let onChange: EventHandler<Event, HTMLSelectElement> = () => {};
 </script>

--- a/src/lib/components/WikiSelectMenu.svelte
+++ b/src/lib/components/WikiSelectMenu.svelte
@@ -27,6 +27,7 @@
   import { resourceDir } from "@tauri-apps/api/path";
   import { type as osTypeFunc } from "@tauri-apps/api/os";
   import updateWildEncounters from "$lib/utils/migration_helpers/updateWildEncounters";
+  import updateTrainerEncounters from "$lib/utils/migration_helpers/updateTrainerEncounters";
 
   const toastStore = getToastStore();
 
@@ -69,9 +70,14 @@
     }
 
     // Update the routes.json file with the new format
-    let updatedRoutes = updateWildEncounters(
-      sortRoutesByPosition(JSON.parse(routesFromFile)),
+    let updatedRoutes = sortRoutesByPosition(
+      updateWildEncounters(JSON.parse(routesFromFile)),
     );
+
+    await updateTrainerEncounters(updatedRoutes).then((newRoutes) => {
+      updatedRoutes = newRoutes;
+    });
+
     await writeTextFile(
       `${$selectedWiki.name}/data/routes.json`,
       JSON.stringify(updatedRoutes),

--- a/src/lib/components/WikiSelectMenu.svelte
+++ b/src/lib/components/WikiSelectMenu.svelte
@@ -89,9 +89,8 @@
       `${$selectedWiki.name}/data/types.json`,
       { dir: BaseDirectory.AppData },
     );
+    const resourceDirectory = await resourceDir();
     if (!typesJsonExists) {
-      const resourceDirectory = await resourceDir();
-
       let typesDirectory = `${resourceDirectory}resources/generator_assets/starting_data/types.json`;
 
       if (osType === "Windows_NT") {
@@ -114,6 +113,19 @@
       timeout: 2000,
       background: "variant-filled-success",
     });
+
+    // update css
+    let cssDirectory = `${resourceDirectory}resources/generator_assets/stylesheets/extra.css`;
+    if (osType === "Windows_NT") {
+      cssDirectory = cssDirectory.replaceAll("/", "\\");
+    }
+    await copyFile(
+      cssDirectory,
+      `${$selectedWiki.name}/dist/docs/stylesheets/extra.css`,
+      {
+        dir: BaseDirectory.AppData,
+      },
+    );
   }
 
   async function deleteWikis() {

--- a/src/lib/components/WikiSelectMenu.svelte
+++ b/src/lib/components/WikiSelectMenu.svelte
@@ -158,11 +158,16 @@
         // Load Pokemon
         $db
           .select(
-            "SELECT id, dex_number, name FROM pokemon ORDER BY dex_number",
+            "SELECT id, dex_number, name, types FROM pokemon ORDER BY dex_number",
           )
           .then((pokemon: any) => {
             pokemonList.set(
-              pokemon.map((p: SearchPokemon) => [p.id, p.dex_number, p.name]),
+              pokemon.map((p: SearchPokemon) => [
+                p.id,
+                p.dex_number,
+                p.name,
+                p.types,
+              ]),
             );
           });
 

--- a/src/lib/components/WikiSelectMenu.svelte
+++ b/src/lib/components/WikiSelectMenu.svelte
@@ -28,6 +28,7 @@
   import { type as osTypeFunc } from "@tauri-apps/api/os";
   import updateWildEncounters from "$lib/utils/migration_helpers/updateWildEncounters";
   import updateTrainerEncounters from "$lib/utils/migration_helpers/updateTrainerEncounters";
+  import updateRouteRender from "$lib/utils/migration_helpers/updateRouteRenderValue";
 
   const toastStore = getToastStore();
 
@@ -77,6 +78,8 @@
     await updateTrainerEncounters(updatedRoutes).then((newRoutes) => {
       updatedRoutes = newRoutes;
     });
+
+    updatedRoutes = updateRouteRender(updatedRoutes);
 
     await writeTextFile(
       `${$selectedWiki.name}/data/routes.json`,

--- a/src/lib/components/game-route-components/TrainerEncounters.svelte
+++ b/src/lib/components/game-route-components/TrainerEncounters.svelte
@@ -65,7 +65,7 @@
 
   function addPokemonToTrainer() {
     let searchedPokemon = $pokemonList.find(
-      ([_, __, name]) => name === pokemonSearchName.toLowerCase(),
+      ([_, __, name, ___]) => name === pokemonSearchName.toLowerCase(),
     );
 
     if (searchedPokemon === undefined) {
@@ -96,12 +96,21 @@
       $pokemonList,
     );
 
+    let type_one = searchedPokemon[3].split(",")[0];
+    let type_two =
+      searchedPokemon[3].split(",").length > 1
+        ? searchedPokemon[3].split(",")[1]
+        : "";
+
+    let types = type_two === "" ? [type_one] : [type_one, type_two];
+
     routeTrainers[trainerName].pokemon_team = [
       ...routeTrainers[trainerName].pokemon_team,
       {
         id: id,
         unique_id: uniqueId,
         name: pokemonSearchName.toLowerCase(),
+        types: types,
         level,
         item: "",
         nature: "",
@@ -110,6 +119,8 @@
         moves: [],
       },
     ];
+
+    console.log(routeTrainers[trainerName].pokemon_team);
 
     let sortedTrainers = sortTrainersByPosition(routeTrainers);
     routeTrainers = sortedTrainers;

--- a/src/lib/components/game-route-components/TrainerEncounters.svelte
+++ b/src/lib/components/game-route-components/TrainerEncounters.svelte
@@ -307,7 +307,7 @@
     class="w-40"
   />
   <AutoComplete
-    label="Pokemon for current encounter type"
+    label="Pokemon for current encounter area"
     placeholder="Pokemon Name"
     bind:value={pokemonSearchName}
     options={pokemonListOptions}

--- a/src/lib/components/game-route-components/TrainerEncounters.svelte
+++ b/src/lib/components/game-route-components/TrainerEncounters.svelte
@@ -192,9 +192,9 @@
       JSON.stringify($routes),
       { dir: BaseDirectory.AppData },
     ).then(() => {
-      invoke("generate_single_route_page_with_handle", {
+      invoke("generate_route_pages_with_handle", {
         wikiName: $selectedWiki.name,
-        routeName,
+        routeNames: [routeName],
       })
         .then(() => {
           toastStore.trigger({

--- a/src/lib/components/game-route-components/TrainerEncounters.svelte
+++ b/src/lib/components/game-route-components/TrainerEncounters.svelte
@@ -96,21 +96,13 @@
       $pokemonList,
     );
 
-    let type_one = searchedPokemon[3].split(",")[0];
-    let type_two =
-      searchedPokemon[3].split(",").length > 1
-        ? searchedPokemon[3].split(",")[1]
-        : "";
-
-    let types = type_two === "" ? [type_one] : [type_one, type_two];
-
     routeTrainers[trainerName].pokemon_team = [
       ...routeTrainers[trainerName].pokemon_team,
       {
         id: id,
         unique_id: uniqueId,
         name: pokemonSearchName.toLowerCase(),
-        types: types,
+        types: searchedPokemon[3].split(","),
         level,
         item: "",
         nature: "",

--- a/src/lib/components/game-route-components/WildEncounters.svelte
+++ b/src/lib/components/game-route-components/WildEncounters.svelte
@@ -83,6 +83,8 @@
         },
       ],
     };
+
+    console.log(routeWildEncounters[encounterType]);
     routeWildEncounters[encounterType]
       .sort(
         (encounter1, encounter2) =>

--- a/src/lib/components/game-route-components/WildEncounters.svelte
+++ b/src/lib/components/game-route-components/WildEncounters.svelte
@@ -224,7 +224,7 @@
   <Button
     class="mt-8 w-32"
     title="Add Encounter"
-    disabled={pokemonName === "" || encounterRate === 0}
+    disabled={pokemonName === ""}
     onClick={addEncounter}
   />
   <Button

--- a/src/lib/components/game-route-components/WildEncounters.svelte
+++ b/src/lib/components/game-route-components/WildEncounters.svelte
@@ -84,7 +84,6 @@
       ],
     };
 
-    console.log(routeWildEncounters[encounterType]);
     routeWildEncounters[encounterType]
       .sort(
         (encounter1, encounter2) =>

--- a/src/lib/components/game-route-components/WildEncounters.svelte
+++ b/src/lib/components/game-route-components/WildEncounters.svelte
@@ -131,9 +131,9 @@
       JSON.stringify($routes),
       { dir: BaseDirectory.AppData },
     ).then(() => {
-      invoke("generate_single_route_page_with_handle", {
+      invoke("generate_route_pages_with_handle", {
         wikiName: $selectedWiki.name,
-        routeName,
+        routeNames: [routeName],
       })
         .then(() => {
           toastStore.trigger({

--- a/src/lib/components/game-route-components/WildEncounters.svelte
+++ b/src/lib/components/game-route-components/WildEncounters.svelte
@@ -43,7 +43,7 @@
   let pokemonListOptions: AutocompleteOption<string | number>[] =
     $pokemonList.map(([id, _, name]) => ({ label: name, value: id }));
 
-  const encounterTypes = $routes.encounter_types.map((type) => ({
+  const encounterTypes = $routes.encounter_areas.map((type) => ({
     label: type,
     value: type,
   }));
@@ -77,7 +77,7 @@
           id: searchedPokemon[1],
           name: pokemonName.toLowerCase(),
           encounter_rate: encounterRate,
-          encounter_type: encounterType,
+          encounter_area: encounterType,
           special_note: "",
           route: routeName,
         },
@@ -200,14 +200,14 @@
   <div class="w-40">
     <SelectInput
       id="encounter-type"
-      label="Encounter Type"
+      label="Encounter Area"
       bind:value={encounterType}
       options={encounterTypes}
     />
   </div>
 
   <AutoComplete
-    label="Pokemon for current encounter type"
+    label="Pokemon for current encounter area"
     placeholder="Pokemon Name"
     bind:value={pokemonName}
     options={pokemonListOptions}

--- a/src/lib/components/game-route-components/WildEncounters.svelte
+++ b/src/lib/components/game-route-components/WildEncounters.svelte
@@ -27,7 +27,7 @@
 
   export let routeName: string = "";
   let pokemonName: string = "";
-  let encounterType: string = "grass-normal";
+  let encounterArea: string = "grass";
   let currentWildEncounterIndex: number;
   let currentEncounterType: string;
   let editEncounterModalOpen: boolean = false;
@@ -43,7 +43,7 @@
   let pokemonListOptions: AutocompleteOption<string | number>[] =
     $pokemonList.map(([id, _, name]) => ({ label: name, value: id }));
 
-  const encounterTypes = $routes.encounter_areas.map((type) => ({
+  const encounterAreas = $routes.encounter_areas.map((type) => ({
     label: type,
     value: type,
   }));
@@ -71,20 +71,20 @@
 
     routeWildEncounters = {
       ...routeWildEncounters,
-      [encounterType]: [
-        ...(routeWildEncounters[encounterType] ?? []),
+      [encounterArea]: [
+        ...(routeWildEncounters[encounterArea] ?? []),
         {
           id: searchedPokemon[1],
           name: pokemonName.toLowerCase(),
           encounter_rate: encounterRate,
-          encounter_area: encounterType,
+          encounter_area: encounterArea,
           special_note: "",
           route: routeName,
         },
       ],
     };
 
-    routeWildEncounters[encounterType]
+    routeWildEncounters[encounterArea]
       .sort(
         (encounter1, encounter2) =>
           encounter1.encounter_rate - encounter2.encounter_rate,
@@ -92,20 +92,20 @@
       .reverse();
   }
 
-  async function deleteEncounter(pokemonName: string, encounterType: string) {
+  async function deleteEncounter(pokemonName: string, encounterArea: string) {
     editEncounterModalOpen = false;
     let updatedEncounters = {
       ...routeWildEncounters,
     };
-    updatedEncounters[encounterType] = updatedEncounters[encounterType].filter(
+    updatedEncounters[encounterArea] = updatedEncounters[encounterArea].filter(
       (encounter) => encounter.name !== pokemonName,
     );
-    if (updatedEncounters[encounterType].length === 0) {
-      delete updatedEncounters[encounterType];
+    if (updatedEncounters[encounterArea].length === 0) {
+      delete updatedEncounters[encounterArea];
     }
 
-    if (updatedEncounters[encounterType] !== undefined) {
-      updatedEncounters[encounterType]
+    if (updatedEncounters[encounterArea] !== undefined) {
+      updatedEncounters[encounterArea]
         .sort(
           (encounter1, encounter2) =>
             encounter1.encounter_rate - encounter2.encounter_rate,
@@ -200,10 +200,10 @@
 >
   <div class="w-40">
     <SelectInput
-      id="encounter-type"
+      id="encounter-area"
       label="Encounter Area"
-      bind:value={encounterType}
-      options={encounterTypes}
+      bind:value={encounterArea}
+      options={encounterAreas}
     />
   </div>
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -232,13 +232,13 @@ export const setUniquePokemonId = (
   trainers: { [key: string]: TrainerInfo },
   trainerName: string,
   pokemonName: string,
-  pokemonList: [number, number, string][],
+  pokemonList: [number, number, string, string][],
 ) => {
   let teamLength = 0;
 
   if (isNullEmptyOrUndefined(trainers)) {
     return `${
-      pokemonList.find(([id, _, name]) => name === pokemonName)?.[1]
+      pokemonList.find(([id, _, name, __]) => name === pokemonName)?.[1]
     }_${teamLength}_${Math.floor(Math.random() * 9000 + 1000)}`;
   }
 
@@ -248,7 +248,7 @@ export const setUniquePokemonId = (
     }
   }
   return `${
-    pokemonList?.find(([id, _, name]) => name === pokemonName)?.[1]
+    pokemonList?.find(([id, _, name, __]) => name === pokemonName)?.[1]
   }_${teamLength}_${Math.floor(Math.random() * 9000 + 1000)}`;
 };
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -194,12 +194,12 @@ export function sortRoutesByPosition(routes: Routes): Routes {
   );
 
   // Reconstruct the sorted object
-  const sortedRoutes: Routes = { routes: {}, encounter_types: [] };
+  const sortedRoutes: Routes = { routes: {}, encounter_areas: [] };
   routesArray.forEach(([routeName, route]) => {
     sortedRoutes.routes[routeName] = route;
   });
 
-  sortedRoutes.encounter_types = routes.encounter_types;
+  sortedRoutes.encounter_areas = routes.encounter_areas;
 
   return sortedRoutes;
 }

--- a/src/lib/utils/migration_helpers/updateRouteRenderValue.ts
+++ b/src/lib/utils/migration_helpers/updateRouteRenderValue.ts
@@ -1,0 +1,16 @@
+import type { Routes } from "../../../store/gameRoutes";
+
+export default function updateRouteRender(routes: Routes): Routes {
+  let updatedRoutes = routes;
+
+  for (const [routeName, routeProperties] of Object.entries(
+    updatedRoutes.routes,
+  )) {
+    if (routeProperties.render !== undefined) {
+      continue;
+    }
+    routeProperties.render = true;
+  }
+
+  return updatedRoutes;
+}

--- a/src/lib/utils/migration_helpers/updateTrainerEncounters.ts
+++ b/src/lib/utils/migration_helpers/updateTrainerEncounters.ts
@@ -1,0 +1,35 @@
+import { get } from "svelte/store";
+import { db } from "../../../store/db";
+import type { Routes } from "../../../store/gameRoutes";
+import type { Pokemon } from "../../../store/pokemon";
+
+export default async function updateTrainerEncounters(
+  routes: Routes,
+): Promise<Routes> {
+  let database = get(db);
+  let updatedRoutes = routes;
+
+  for (const [routeName, routeProperties] of Object.entries(
+    updatedRoutes.routes,
+  )) {
+    for (const [name, trainerInfo] of Object.entries(
+      routeProperties.trainers,
+    )) {
+      for (const [index, pokemon] of trainerInfo.pokemon_team.entries()) {
+        await database
+          .select<
+            Pokemon[]
+          >(`SELECT * FROM pokemon WHERE name = $1;`, [pokemon.name])
+          .then((res) => {
+            updatedRoutes.routes[routeName].trainers[name].pokemon_team[index] =
+              {
+                ...pokemon,
+                types: res[0].types.split(","),
+              };
+          });
+      }
+    }
+  }
+
+  return updatedRoutes;
+}

--- a/src/lib/utils/migration_helpers/updateWildEncounters.ts
+++ b/src/lib/utils/migration_helpers/updateWildEncounters.ts
@@ -16,7 +16,7 @@ export default function updateWildEncounters(routes: Routes): Routes {
             ...encounter,
             route: routeName,
             special_note: "",
-            encounter_type: encounterArea,
+            encounter_area: encounterArea,
           };
       }
     }

--- a/src/lib/utils/migration_helpers/updateWildEncounters.ts
+++ b/src/lib/utils/migration_helpers/updateWildEncounters.ts
@@ -1,7 +1,8 @@
 import { get } from "svelte/store";
 import type { Routes } from "../../../store/gameRoutes";
 
-export default function updateWildEncounters(routes: Routes): Routes {
+export default function updateWildEncounters(routes: any): Routes {
+  console.log({ routes });
   let updatedRoutes = routes;
 
   for (const [routeName, routeProperties] of Object.entries(
@@ -18,8 +19,17 @@ export default function updateWildEncounters(routes: Routes): Routes {
             special_note: "",
             encounter_area: encounterArea,
           };
+        delete updatedRoutes.routes[routeName].wild_encounters[encounterArea][
+          index
+        ].encounter_type;
       }
     }
+  }
+  if (updatedRoutes.encounter_types === undefined) {
+    updatedRoutes.encounter_areas = [];
+  } else {
+    updatedRoutes.encounter_areas = [...updatedRoutes.encounter_types];
+    delete updatedRoutes.encounter_types;
   }
 
   return updatedRoutes;

--- a/src/lib/utils/migration_helpers/updateWildEncounters.ts
+++ b/src/lib/utils/migration_helpers/updateWildEncounters.ts
@@ -26,7 +26,12 @@ export default function updateWildEncounters(routes: any): Routes {
     }
   }
   if (updatedRoutes.encounter_types === undefined) {
-    updatedRoutes.encounter_areas = [];
+    if (
+      updatedRoutes.encounter_areas === undefined ||
+      updatedRoutes.encounter_areas.length === 0
+    ) {
+      updatedRoutes.encounter_areas = [];
+    }
   } else {
     updatedRoutes.encounter_areas = [...updatedRoutes.encounter_types];
     delete updatedRoutes.encounter_types;

--- a/src/routes/game-routes/+page.svelte
+++ b/src/routes/game-routes/+page.svelte
@@ -93,8 +93,10 @@
 
   async function generateRoutePages() {
     loading = true;
+    let routeNames = Object.keys($routes.routes);
     await invoke("generate_route_pages_with_handle", {
       wikiName: $selectedWiki.name,
+      routeNames,
     }).then((response: any) => {
       loading = false;
       toastStore.trigger({

--- a/src/routes/game-routes/+page.svelte
+++ b/src/routes/game-routes/+page.svelte
@@ -55,7 +55,7 @@
   }
 
   async function addNewEncounterType() {
-    $routes.encounter_types = [...$routes.encounter_types, newEncounterType];
+    $routes.encounter_areas = [...$routes.encounter_areas, newEncounterType];
     await writeTextFile(
       `${$selectedWiki.name}/data/routes.json`,
       JSON.stringify(sortRoutesByPosition($routes)),
@@ -64,7 +64,7 @@
   }
 
   async function deleteEncounterType(encounterType: string) {
-    $routes.encounter_types = $routes.encounter_types.filter(
+    $routes.encounter_areas = $routes.encounter_areas.filter(
       (type) => type !== encounterType,
     );
     await writeTextFile(
@@ -162,7 +162,7 @@
   />
 </BaseModal>
 
-<!-- Encounter Type Modal -->
+<!-- Encounter Area Modal -->
 <BaseModal bind:open={encounterTypeModalOpen}>
   <div class="flex flex-row gap-3">
     <Button
@@ -171,10 +171,10 @@
       onClick={addNewEncounterType}
       disabled={newEncounterType === ""}
     />
-    <TextInput bind:value={newEncounterType} placeholder="New Encounter Type" />
+    <TextInput bind:value={newEncounterType} placeholder="New Encounter Area" />
   </div>
   <div class="grid grid-cols-2 gap-3">
-    {#each $routes.encounter_types as encounterType}
+    {#each $routes.encounter_areas as encounterType}
       <div class="card flex flex-row items-center justify-between px-2 py-1">
         {encounterType}
         <button
@@ -196,7 +196,7 @@
   />
   <Button
     class="w-48"
-    title="Modify Encounter Types"
+    title="Modify Encounter Areas"
     onClick={() => (encounterTypeModalOpen = true)}
   />
   <Button

--- a/src/routes/game-routes/+page.svelte
+++ b/src/routes/game-routes/+page.svelte
@@ -39,6 +39,7 @@
     }
 
     $routes.routes[routeName.trim()] = {
+      render: true,
       position: Object.keys($routes.routes).length + 1,
       trainers: {},
       wild_encounters: {},

--- a/src/routes/game-routes/+page.svelte
+++ b/src/routes/game-routes/+page.svelte
@@ -24,6 +24,20 @@
   let loading = false;
 
   async function createNewRoute() {
+    if (routeName.trim() === "") {
+      return;
+    }
+
+    if ($routes.routes[routeName.trim()]) {
+      toastStore.trigger({
+        message: "Route already exists",
+        timeout: 5000,
+        hoverable: true,
+        background: "variant-filled-error",
+      });
+      return;
+    }
+
     $routes.routes[routeName.trim()] = {
       position: Object.keys($routes.routes).length + 1,
       trainers: {},
@@ -34,7 +48,10 @@
       `${$selectedWiki.name}/data/routes.json`,
       JSON.stringify($routes),
       { dir: BaseDirectory.AppData },
-    );
+    ).then(() => {
+      routeName = "";
+      newRouteModalOpen = false;
+    });
   }
 
   async function addNewEncounterType() {
@@ -125,7 +142,6 @@
     title="Save New Route"
     onClick={() => {
       createNewRoute();
-      newRouteModalOpen = false;
     }}
     disabled={routeName === ""}
   />

--- a/src/routes/game-routes/[slug]/+page.svelte
+++ b/src/routes/game-routes/[slug]/+page.svelte
@@ -1,11 +1,40 @@
 <script lang="ts">
-import TrainerEncounters from "$lib/components/game-route-components/TrainerEncounters.svelte";
-import WildEncounters from "$lib/components/game-route-components/WildEncounters.svelte";
-import { Tab, TabGroup } from "@skeletonlabs/skeleton";
-import { IconArrowLeft } from "@tabler/icons-svelte";
+  import TrainerEncounters from "$lib/components/game-route-components/TrainerEncounters.svelte";
+  import WildEncounters from "$lib/components/game-route-components/WildEncounters.svelte";
+  import SelectInput from "$lib/components/SelectInput.svelte";
+  import { getToastStore, Tab, TabGroup } from "@skeletonlabs/skeleton";
+  import { IconArrowLeft } from "@tabler/icons-svelte";
+  import { routes } from "../../../store/gameRoutes";
+  import { selectedWiki } from "../../../store";
+  import { BaseDirectory, writeTextFile } from "@tauri-apps/api/fs";
+  import { invoke } from "@tauri-apps/api";
 
-export let data;
-let tabSet: number = 0;
+  const toastStore = getToastStore();
+  export let data;
+  let tabSet: number = 0;
+
+  async function saveRenderChange() {
+    await writeTextFile(
+      `${$selectedWiki.name}/data/routes.json`,
+      JSON.stringify($routes),
+      { dir: BaseDirectory.AppData },
+    ).then(() => {
+      invoke("generate_route_pages_with_handle", {
+        wikiName: $selectedWiki.name,
+        routeNames: [data.title],
+      })
+        .then(() => {
+          toastStore.trigger({
+            message: "Render Value Updated",
+            timeout: 3000,
+            background: "variant-filled-success",
+          });
+        })
+        .catch((e) => {
+          console.error(e);
+        });
+    });
+  }
 </script>
 
 <strong class="text-l flex flex-row items-center gap-5">
@@ -21,12 +50,34 @@ let tabSet: number = 0;
   <Tab bind:group={tabSet} name="trainer-encounters" value={1} class="text-sm"
     >Trainer Encounters</Tab
   >
+  <Tab bind:group={tabSet} name="properties" value={2} class="text-sm"
+    >Properties</Tab
+  >
   <svelte:fragment slot="panel">
     {#if tabSet === 0}
       <WildEncounters routeName={data.title} />
     {/if}
     {#if tabSet === 1}
       <TrainerEncounters routeName={data.title} />
+    {/if}
+    {#if tabSet === 2}
+      <div class="w-36">
+        <SelectInput
+          label="Render Route Page"
+          bind:value={$routes.routes[data.title].render}
+          options={[
+            {
+              value: true,
+              label: "True",
+            },
+            {
+              value: false,
+              label: "False",
+            },
+          ]}
+          onChange={saveRenderChange}
+        />
+      </div>
     {/if}
   </svelte:fragment>
 </TabGroup>

--- a/src/store/gameRoutes.ts
+++ b/src/store/gameRoutes.ts
@@ -28,6 +28,7 @@ export type TrainerInfo = {
 export type TrainerPokemon = {
   id: number;
   unique_id: string;
+  types: string[];
   name: string;
   level: number;
   moves: string[];

--- a/src/store/gameRoutes.ts
+++ b/src/store/gameRoutes.ts
@@ -2,7 +2,7 @@ import { writable } from "svelte/store";
 
 export type Routes = {
   routes: { [key: string]: RouteProperties };
-  encounter_types: string[];
+  encounter_areas: string[];
 };
 
 export type RouteProperties = {
@@ -41,7 +41,7 @@ export type WildEncounter = {
   id: number;
   name: string;
   encounter_rate: number;
-  encounter_type: string;
+  encounter_area: string;
   route: string;
   special_note: string;
 };

--- a/src/store/gameRoutes.ts
+++ b/src/store/gameRoutes.ts
@@ -6,6 +6,7 @@ export type Routes = {
 };
 
 export type RouteProperties = {
+  render: boolean;
   position: number;
   trainers: {
     [key: string]: TrainerInfo;

--- a/src/store/pokemon.ts
+++ b/src/store/pokemon.ts
@@ -4,6 +4,7 @@ export type SearchPokemon = {
   id: number;
   dex_number: number;
   name: string;
+  types: string;
 };
 
 export type Pokemon = {
@@ -84,4 +85,4 @@ export const PokemonTypes = [
   "fairy",
 ];
 
-export let pokemonList = writable<[number, number, string][]>([]);
+export let pokemonList = writable<[number, number, string, string][]>([]);


### PR DESCRIPTION
Changelog:
- Consolidated Wild and Trainer Encounters onto a single page.
- Updated Design of both Wild and Trainer Encounters.
- Added ability to determine whether or not a route gets rendered.
- Fixed issue where ability flavor text wasn't being displayed properly


https://github.com/user-attachments/assets/0625a80a-56c9-417b-a8b8-f40a90a3e3bc

